### PR TITLE
Fix the selected date shown by datepicker in Date.component.vue

### DIFF
--- a/ui/src/components/manage-entities/Date.component.vue
+++ b/ui/src/components/manage-entities/Date.component.vue
@@ -4,7 +4,7 @@
             v-model="internalValue"
             type="date"
             placeholder="Pick a date"
-            format="yyyy-MM-dd"
+            format="YYYY-MM-DD"
             @change="save"
             :clearable="true"
         >


### PR DESCRIPTION
See https://github.com/Sciebo-RDS/describo-online/issues/1

Also, what is the intended behavior for the datepicker? The function `startOfDay` does not return the start of day as I (personally) would expect in this context, but the local start of the day, converted to UTC, see [here](https://github.com/date-fns/date-fns/issues/1551). This might be intended behavior and not in issue, it just had me wondering.