### PR TITLE
UI fixes: Match template list and entity list to look the same

### DIFF
--- a/ui/src/components/entity-list/Shell.component.vue
+++ b/ui/src/components/entity-list/Shell.component.vue
@@ -1,6 +1,6 @@
 <template>
-    <div class="flex flex-col">
-        <div class="flex flex-col space-y-2">
+    <div class="flex flex-col space-y-2">
+        <div class="flex flex-col">
             <!-- <add-entity-component @add-entity="addNewEntity" /> -->
 
             <div class="flex flex-row space-x-2">
@@ -20,7 +20,7 @@
                 </el-pagination>
             </div>
         </div>
-        <el-table :data="data.entities" highlight-current-row>
+        <el-table :data="data.entities" highlight-current-row v-loading="loading">
             <el-table-column prop="etype" label="@type" width="180"> </el-table-column>
             <el-table-column prop="eid" label="@id" width="400"> </el-table-column>
             <el-table-column prop="name" label="Name"> </el-table-column>
@@ -36,7 +36,7 @@
                     </div>
                 </template>
             </el-table-column>
-            <el-table-column label="Actions" width="150">
+            <el-table-column label="Actions" width="100">
                 <template #default="scope">
                     <div class="flex flex-row space-x-2">
                         <div>

--- a/ui/src/components/entity-list/Shell.component.vue
+++ b/ui/src/components/entity-list/Shell.component.vue
@@ -49,7 +49,7 @@
                                 @click="deleteEntity(scope.row.id)"
                                 size="small"
                                 type="danger"
-                                v-if="scope.row.eid !== './'"
+                                :disabled="scope.row.eid == './'"
                             >
                                 <i class="fas fa-trash"></i>
                             </el-button>

--- a/ui/src/components/template-list/TemplateList.component.vue
+++ b/ui/src/components/template-list/TemplateList.component.vue
@@ -1,64 +1,62 @@
 <template>
-    <el-card>
-        <div class="flex flex-col space-y-4">
-            <div class="flex flex-col">
-                <div class="flex flex-row space-x-2">
-                    <el-input
-                        placeholder="filter by name and @id"
-                        v-model="filter"
-                        @input="debouncedGetTemplates"
-                        :clearable="true"
-                        size="small"
-                    >
-                    </el-input>
-                    <el-pagination
-                        class="ml-2"
-                        layout="total, prev, pager, next"
-                        :total="data.total"
-                        @current-change="nextPage"
-                    >
-                    </el-pagination>
-                </div>
+    <div class="flex flex-col space-y-2">
+        <div class="flex flex-col">
+            <div class="flex flex-row space-x-2">
+                <el-input
+                    placeholder="filter by name and @id"
+                    v-model="filter"
+                    @input="debouncedGetTemplates"
+                    :clearable="true"
+                    size="small"
+                >
+                </el-input>
+                <el-pagination
+                    class="ml-2"
+                    layout="total, prev, pager, next"
+                    :total="data.total"
+                    @current-change="nextPage"
+                >
+                </el-pagination>
             </div>
-            <el-table :data="data.templates" highlight-current-row v-loading="loading">
-                <template #empty>You don't have any saved templates </template>
-                <el-table-column prop="etype" label="@type" width="180"> </el-table-column>
-                <el-table-column prop="eid" label="@id" width="400"> </el-table-column>
-                <el-table-column prop="name" label="Name"> </el-table-column>
-                <el-table-column prop="src" label="Entity Data" type="expand" width="120">
-                    <template #default="scope">
-                        <pre>{{ JSON.stringify(scope.row.src, null, 2) }}</pre>
-                    </template>
-                </el-table-column>
-                <el-table-column label="Actions" width="100" align="center">
-                    <template #default="scope">
-                        <div class="flex flex-row space-x-2">
-                        <div>
-                                <el-button
-                                    @click="applyCrateTemplate(scope.row.id)"
-                                    size="small"
-                                    type="primary"
-                                :disabled="scope.row.etype && scope.row.eid"
-                                >
-                                    <i class="fas fa-check-double"></i>
-                                </el-button>
-                            </div>
-                            <div>
-                                <el-button
-                                    @click="deleteTemplate(scope.row.id)"
-                                    size="small"
-                                    type="danger"
-                                :disabled="scope.row.eid == './'"
-                                >
-                                    <i class="fas fa-trash"></i>
-                                </el-button>
-                            </div>
-                        </div>
-                    </template>
-                </el-table-column>
-            </el-table>
         </div>
-    </el-card>
+        <el-table :data="data.templates" highlight-current-row v-loading="loading">
+            <template #empty>You don't have any saved templates </template>
+            <el-table-column prop="etype" label="@type" width="180"> </el-table-column>
+            <el-table-column prop="eid" label="@id" width="400"> </el-table-column>
+            <el-table-column prop="name" label="Name"> </el-table-column>
+            <el-table-column prop="src" label="Entity Data" type="expand" width="120">
+                <template #default="scope">
+                    <pre>{{ JSON.stringify(scope.row.src, null, 2) }}</pre>
+                </template>
+            </el-table-column>
+            <el-table-column label="Actions" width="100">
+                <template #default="scope">
+                    <div class="flex flex-row space-x-2">
+                        <div>
+                            <el-button
+                                @click="applyCrateTemplate(scope.row.id)"
+                                size="small"
+                                type="primary"
+                                :disabled="scope.row.etype && scope.row.eid"
+                            >
+                                <i class="fas fa-check-double"></i>
+                            </el-button>
+                        </div>
+                        <div>
+                            <el-button
+                                @click="deleteTemplate(scope.row.id)"
+                                size="small"
+                                type="danger"
+                                :disabled="scope.row.eid == './'"
+                            >
+                                <i class="fas fa-trash"></i>
+                            </el-button>
+                        </div>
+                    </div>
+                </template>
+            </el-table-column>
+        </el-table>
+    </div>
 </template>
 
 <script setup>

--- a/ui/src/components/template-list/TemplateList.component.vue
+++ b/ui/src/components/template-list/TemplateList.component.vue
@@ -33,11 +33,12 @@
                 <el-table-column label="Actions" width="100" align="center">
                     <template #default="scope">
                         <div class="flex flex-row space-x-2">
-                            <div v-if="!scope.row.etype && !scope.row.eid">
+                        <div>
                                 <el-button
                                     @click="applyCrateTemplate(scope.row.id)"
                                     size="small"
                                     type="primary"
+                                :disabled="scope.row.etype && scope.row.eid"
                                 >
                                     <i class="fas fa-check-double"></i>
                                 </el-button>
@@ -47,7 +48,7 @@
                                     @click="deleteTemplate(scope.row.id)"
                                     size="small"
                                     type="danger"
-                                    v-if="scope.row.eid !== './'"
+                                :disabled="scope.row.eid == './'"
                                 >
                                     <i class="fas fa-trash"></i>
                                 </el-button>


### PR DESCRIPTION
The "Browse Collection Entities" and "Manage Templates" tabs are essentially the same visually, but had a few minor styling differences which lead to the table jumping around when switching between these tabs (especially noticable in the filter and header). This PR fixes these differences and makes both components look the same, removing the jitter.

Changes made:
- removed `<el-card>` from TemplateList to match Entity list
- matched alignments and widths
- `disable` action buttons instead of `v-if`, to fix cases where the `delete template` button would float to the left (when templates ware deletable but not applicable)


Before:

https://user-images.githubusercontent.com/31971585/178012440-c90b6713-6942-4b51-961b-776f458851b8.mov


After:

https://user-images.githubusercontent.com/31971585/178012524-12bc4179-de1d-4ba7-a869-1f463a3407f3.mov


