### PR TITLE
Reset template name input after template is saved

### DIFF
--- a/ui/src/components/manage-entities/SaveCrateAsTemplateDialog.component.vue
+++ b/ui/src/components/manage-entities/SaveCrateAsTemplateDialog.component.vue
@@ -47,6 +47,7 @@ export default {
         },
         save() {
             this.$emit("save:crate-as-template", { name: this.crateName });
+            this.crateName = undefined;
         },
     },
 };


### PR DESCRIPTION
Resets the crate template name input field after clicking the `save` button.