### PR TITLE
Improve Filebrowser with icons and file sizes

### DIFF
--- a/ui/src/components/filebrowser/FileBrowser.component.vue
+++ b/ui/src/components/filebrowser/FileBrowser.component.vue
@@ -3,10 +3,10 @@
         <div class="flex flex-col w-full">
             <div class="flex flex-row" v-if="props.enableFileSelector">
                 <div class="w-3/5 flex-grow px-2">
-                    <div v-if="props.mode === 'openFile'">
-                        <el-checkbox v-model="selectAllChildren">
-                            Select all children when adding folders
-                        </el-checkbox>
+                    <div v-if="props.mode === 'openFile'" class="m-2">
+                        <el-switch
+                            v-model="selectAllChildren"
+                            active-text="Select all children when adding folders"/>
                     </div>
                     <div>
                         <el-tree

--- a/ui/src/components/filebrowser/FileBrowser.component.vue
+++ b/ui/src/components/filebrowser/FileBrowser.component.vue
@@ -191,12 +191,12 @@ function renderContent(h, { node, data, store }) {
     return(
         h('div', {class : 'border-b flex grow max-w-full truncate '},
             [
-                h('i', {class: 'fa mx-2 mt-0.5 text-gray-400 ' + (!this.node.data.isDir ? matchIconWithMimeType(node.data.mimeType) : "fa-folder")}),
+                h('i', {class: 'fa mx-2 mt-0.5 text-gray-400 ' + (!this.node.data.isDir ? matchMimeTypeWithIcon(node.data.mimeType) : "fa-folder")}),
                 h('span', {class: 'grow truncate mr-10'}, this.node.data.name),
                 h('span', {class: 'text-gray-400 min-w-fit'} , (!this.node.data.isDir ? formatBytes(this.node.data.size) : null))
             ]))
 }
-function matchIconWithMimeType(mimeType){
+function matchMimeTypeWithIcon(mimeType){
     switch(true) {
         case mimeType.startsWith('audio'):
             return 'fa-file-audio'

--- a/ui/src/components/filebrowser/FileBrowser.component.vue
+++ b/ui/src/components/filebrowser/FileBrowser.component.vue
@@ -192,7 +192,7 @@ function renderContent(h, { node, data, store }) {
         h('div', {class : 'border-b flex grow max-w-full truncate '},
             [
                 h('i', {class: 'fa mx-2 mt-0.5 text-gray-400 ' + (!this.node.data.isDir ? matchMimeTypeWithIcon(node.data.mimeType) : "fa-folder")}),
-                h('span', {class: 'grow truncate mr-10'}, this.node.data.name),
+                h('span', {class: 'grow truncate mr-10', title: this.node.data.name}, this.node.data.name),
                 h('span', {class: 'text-gray-400 min-w-fit'} , (!this.node.data.isDir ? formatBytes(this.node.data.size) : null))
             ]))
 }

--- a/ui/src/components/filebrowser/FileBrowser.component.vue
+++ b/ui/src/components/filebrowser/FileBrowser.component.vue
@@ -8,7 +8,7 @@
                             Select all children when adding folders
                         </el-checkbox>
                     </div>
-                    <div class="overflow-scroll">
+                    <div>
                         <el-tree
                             v-loading="state.loading"
                             ref="tree"
@@ -22,6 +22,7 @@
                             :default-checked-keys="checkedNodes"
                             :default-expanded-keys="defaultExpandedKeys"
                             @check="handleNodeSelection"
+                            :render-content="renderContent"
                         ></el-tree>
                     </div>
                 </div>
@@ -49,7 +50,7 @@
 import { cloneDeep, startsWith, debounce } from "lodash";
 import InformationComponent from "../Information.component.vue";
 import { ElMessage } from "element-plus";
-import { ref, reactive, inject, onMounted } from "vue";
+import { ref, reactive, inject, onMounted, h } from "vue";
 const $http = inject("$http");
 
 const emit = defineEmits(["selected-folder", "selected-nodes"]);
@@ -185,6 +186,47 @@ async function addParts() {
     state.partsAdded = true;
     await new Promise((resolve) => setTimeout(resolve, 4000));
     state.partsAdded = false;
+}
+function renderContent(h, { node, data, store }) {
+    return(
+        h('div', {class : 'border-b flex grow max-w-full truncate '},
+            [
+                h('i', {class: 'fa mx-2 mt-0.5 text-gray-400 ' + (!this.node.data.isDir ? matchIconWithMimeType(node.data.mimeType) : "fa-folder")}),
+                h('span', {class: 'grow truncate mr-10'}, this.node.data.name),
+                h('span', {class: 'text-gray-400 min-w-fit'} , (!this.node.data.isDir ? formatBytes(this.node.data.size) : null))
+            ]))
+}
+function matchIconWithMimeType(mimeType){
+    switch(true) {
+        case mimeType.startsWith('audio'):
+            return 'fa-file-audio'
+        case mimeType.endsWith('pdf'):
+            return 'fa-file-pdf'
+        case mimeType.endsWith('excel' || 'opendocument.spreadsheet'):
+            return 'fa-file-excel'
+        case mimeType.endsWith('powerpoint' || 'opendocument.presentation'):
+            return 'fa-file-powerpoint'
+        case mimeType.endsWith('word' || 'opendocument.text'):
+            return 'fa-file-word'
+        case mimeType.includes('csv'):
+            return 'fa-file-csv'
+        case mimeType.startsWith('image'):
+            return 'fa-file-image'
+        case mimeType.startsWith('video'):
+            return 'fa-file-video'
+        case mimeType.startsWith('text'):
+            return 'fa-file-text'
+        default:
+            return 'fa-file'
+    }
+}
+function formatBytes(bytes, decimals = 2) {
+    if (bytes === 0) return '0 Bytes';
+    const k = 1024;
+    const dm = decimals < 0 ? 0 : decimals;
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
 </script>
 


### PR DESCRIPTION
This PR extends the FileBrowser to show icons corresponding to the mimetype, and file sizes. It also replaces the checkbox that was used to `selectAllChildren` with a switch, which helps to reduce confusion (as the checkbox used before was hard to distinguish from, and looked like part of the Filebrowser tree).

![image](https://user-images.githubusercontent.com/31971585/179749295-9cf6bd90-8938-4e2e-b41a-56b0d79c8f10.png)


Q/suggestion: Is there a reason not to move the info cards on the right to be above the Filebrowser and utilize the 2/3 of additional horizontal space for the Filebrowser?